### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/ehmp/product/production/asu/build.gradle
+++ b/ehmp/product/production/asu/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     compile group: 'org.apache.lucene', name: 'lucene-queryparser', version: '4.0.0'
     compile group: 'org.apache.lucene', name: 'lucene-core', version: '4.0.0'
     compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-smile', version: '2.2.3'
-    compile "commons-collections:commons-collections:3.2.1"
+    compile "commons-collections:commons-collections:3.2.2"
     compile 'joda-time:joda-time:2.2'
     compile("org.apache.poi:poi:3.10-FINAL")
     compile("org.apache.poi:poi-ooxml:3.10-FINAL")

--- a/ehmp/product/production/hmp-main/pom.xml
+++ b/ehmp/product/production/hmp-main/pom.xml
@@ -36,7 +36,7 @@
         <hmp.api.version>0.7.0</hmp.api.version>
         <commons-beanutils.version>1.8.3</commons-beanutils.version>
         <commons-codec.version>1.4</commons-codec.version>
-        <commons-collections.version>3.2.1</commons-collections.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-pool.version>1.6</commons-pool.version>

--- a/ehmp/product/production/vista-support/pom.xml
+++ b/ehmp/product/production/vista-support/pom.xml
@@ -406,7 +406,7 @@
 		<commons.lang.version>2.4</commons.lang.version>
 		<commons.pool.version>1.6</commons.pool.version>
 		<commons.httpclient.version>3.1</commons.httpclient.version>
-		<commons.collections.version>3.2.1</commons.collections.version>
+		<commons.collections.version>3.2.2</commons.collections.version>
 		<commons.codec.version>1.3</commons.codec.version>
 		<commons.io.version>2.1</commons.io.version>
 		<junit.version>4.8.1</junit.version>

--- a/lib/htmlunit-2.7/META-INF/maven/net.sourceforge.htmlunit/htmlunit/pom.xml
+++ b/lib/htmlunit-2.7/META-INF/maven/net.sourceforge.htmlunit/htmlunit/pom.xml
@@ -573,7 +573,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/lib/soapui-5.1.2/META-INF/maven/com.smartbear.soapui/soapui/pom.xml
+++ b/lib/soapui-5.1.2/META-INF/maven/com.smartbear.soapui/soapui/pom.xml
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
